### PR TITLE
Add elimination distance and location tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ parseReplay(replayBuffer, config).then((parsedReplay) => {
 });
 ```
 
+### Elimination events
+
+`playerElim` events now include the eliminator and eliminated player locations as well as the computed distance between them.
+
 ## Optimizing Runtime
 You (very) often don't need all of the data that is parsed, which is why there is an option that lets you specify which data you want to parse. It will also greatly improve the parser's speed. The tutorial on how to do that is [here](./docs/addOwnExports.md).
 

--- a/export/propertyExport/handlePlayerPawn.js
+++ b/export/propertyExport/handlePlayerPawn.js
@@ -12,7 +12,7 @@ const tryGetPlayerDataFromPawn = (pawn, states) => {
   return null;
 };
 
-const handlePlayerPawn = ({ chIndex, data, globalData, states, changedProperties }) => {
+const handlePlayerPawn = ({ chIndex, data, globalData, states, changedProperties, timeSeconds }) => {
   const { actorToChannel } = globalData;
   const { pawnChannelToStateChannel, queuedPlayerPawns, players } = states;
   let playerState;
@@ -55,6 +55,17 @@ const handlePlayerPawn = ({ chIndex, data, globalData, states, changedProperties
     const key = changedProperties[i];
 
     playerState[key] = data[key];
+
+    if (key === 'ReplicatedMovement' && data[key]?.location) {
+      if (!playerState.positions) {
+        playerState.positions = [];
+      }
+
+      playerState.positions.push({
+        time: timeSeconds,
+        location: data[key].location,
+      });
+    }
   }
 };
 

--- a/export/propertyExport/handlePlayerState.js
+++ b/export/propertyExport/handlePlayerState.js
@@ -53,6 +53,22 @@ const handlePlayerState = ({ chIndex, data, states, result, globalData, changedP
     playerData[key] = data[key];
   }
 
+  if (!states.playersById) {
+    states.playersById = {};
+  }
+
+  [
+    playerData.UniqueId,
+    playerData.UniqueID,
+    playerData.BotUniqueId,
+    playerData.PlayerNamePrivate,
+    playerData.PlayerID,
+  ].forEach((id) => {
+    if (id !== undefined && id !== null) {
+      states.playersById[id] = playerData;
+    }
+  });
+
   if (!playerData.bIsABot && data.PlayerNamePrivate) {
     const name = data.PlayerNamePrivate;
 

--- a/src/parseChunks.js
+++ b/src/parseChunks.js
@@ -131,6 +131,47 @@ const parseChunks = async (replay, chunks, globalData) => {
       }
     }
   }
+  const { states } = globalData;
+
+  const getLocationAtTime = (positions, t) => {
+    if (!positions || !positions.length) {
+      return null;
+    }
+
+    for (let i = positions.length - 1; i >= 0; i -= 1) {
+      if (positions[i].time <= t) {
+        return positions[i].location;
+      }
+    }
+
+    return positions[0].location;
+  };
+
+  events.forEach((evt) => {
+    if (evt.group !== 'playerElim') {
+      return;
+    }
+
+    const timeSeconds = evt.startTime / 1000;
+    const eliminatedPlayer = states.playersById?.[evt.eliminated];
+    const eliminatorPlayer = states.playersById?.[evt.eliminator];
+
+    if (eliminatedPlayer) {
+      evt.eliminatedPosition = getLocationAtTime(eliminatedPlayer.positions, timeSeconds);
+    }
+
+    if (eliminatorPlayer) {
+      evt.eliminatorPosition = getLocationAtTime(eliminatorPlayer.positions, timeSeconds);
+    }
+
+    if (evt.eliminatedPosition && evt.eliminatorPosition) {
+      const dx = evt.eliminatedPosition.x - evt.eliminatorPosition.x;
+      const dy = evt.eliminatedPosition.y - evt.eliminatorPosition.y;
+      const dz = evt.eliminatedPosition.z - evt.eliminatorPosition.z;
+
+      evt.distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+  });
 
   return events;
 };

--- a/src/utils/globalData.js
+++ b/src/utils/globalData.js
@@ -61,6 +61,7 @@ class GlobalData {
     this.additionalStates = [
       'pawnChannelToStateChannel',
       'queuedPlayerPawns',
+      'playersById',
     ];
 
     this.exportEmitter = new EventEmitter();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,6 +111,9 @@ interface PlayerElemEvent extends Event {
   eliminator: string,
   gunType: string|number,
   knocked: boolean,
+  eliminatedPosition?: FVector,
+  eliminatorPosition?: FVector,
+  distance?: number,
 }
 
 interface MatchStatsEvent extends Event {


### PR DESCRIPTION
## Summary
- track player positions over time
- compute eliminator/eliminated locations and distance for `playerElim` events
- expose new event fields and type definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa9cd8e04832cbca748ac2031ea16