### PR TITLE
Include bit counts in popOffset error messages

### DIFF
--- a/src/checkpoint.js
+++ b/src/checkpoint.js
@@ -93,9 +93,9 @@ const parseCheckpoint = async (replay, data, globalData) => {
 
   parsePlaybackPackets(binaryReplay, globalData);
 
-  if (!replay.info.IsEncrypted) {
-    replay.popOffset(1)
-  }
+    if (!replay.info.IsEncrypted) {
+      replay.popOffset(1, data.sizeInBytes * 8)
+    }
 };
 
 module.exports = parseCheckpoint;

--- a/src/parse.js
+++ b/src/parse.js
@@ -142,7 +142,7 @@ const replayChunks = (replay, globalData) => {
         console.warn('Unhandled chunkType:', chunkType);
     }
 
-    replay.popOffset(0);
+      replay.popOffset(0, chunkSize * 8);
   }
 
   return chunks;

--- a/src/replayData.js
+++ b/src/replayData.js
@@ -16,9 +16,9 @@ const parseReplayData = async (replay, data, globalData) => {
     parsePlaybackPackets(binaryReplay, globalData);
   }
 
-  if (!replay.info.IsEncrypted) {
-    replay.popOffset(0);
-  };
+    if (!replay.info.IsEncrypted) {
+      replay.popOffset(0, data.length * 8);
+    };
 }
 
 module.exports = parseReplayData;

--- a/src/replayData/parsePlaybackPackets.js
+++ b/src/replayData/parsePlaybackPackets.js
@@ -104,12 +104,12 @@ const parsePlaybackPackets = (replay, globalData) => {
     if (packet.state === 0) {
       receivedRawPacket(packet, replay, globalData);
     } else {
-      replay.popOffset(1);
+      replay.popOffset(1, packet.size * 8);
 
       return;
     }
 
-    replay.popOffset(1);
+    replay.popOffset(1, packet.size * 8);
   }
 };
 

--- a/src/replayData/processBunch.js
+++ b/src/replayData/processBunch.js
@@ -69,7 +69,7 @@ const processBunch = (bunch, replay, globalData) => {
 
     if (bObjectDeleted) {
       if (numPayloadBits > 0) {
-        replay.popOffset(4);
+        replay.popOffset(4, numPayloadBits);
       }
 
       continue;
@@ -77,7 +77,7 @@ const processBunch = (bunch, replay, globalData) => {
 
     if (bunch.archive.isError) {
       if (numPayloadBits > 0) {
-        replay.popOffset(4);
+        replay.popOffset(4, numPayloadBits);
       }
 
       break;
@@ -85,7 +85,7 @@ const processBunch = (bunch, replay, globalData) => {
 
     if (!repObject || !numPayloadBits) {
       if (numPayloadBits > 0) {
-        replay.popOffset(4);
+        replay.popOffset(4, numPayloadBits);
       }
 
       continue;
@@ -93,7 +93,7 @@ const processBunch = (bunch, replay, globalData) => {
 
     receivedReplicatorBunch(bunch, replay, repObject, bOutHasRepLayout, bIsActor, globalData);
     if (numPayloadBits > 0) {
-      replay.popOffset(4);
+      replay.popOffset(4, numPayloadBits);
     }
   }
 };

--- a/src/replayData/readNetExportGuids.js
+++ b/src/replayData/readNetExportGuids.js
@@ -15,7 +15,7 @@ const readNetExportGuids = (replay, globalData) => {
 
     internalLoadObject(replay, true, globalData);
 
-    replay.popOffset(2);
+    replay.popOffset(2, size * 8);
   }
 }
 

--- a/src/replayData/receivedPacket.js
+++ b/src/replayData/receivedPacket.js
@@ -121,19 +121,19 @@ const receivedPacket = (packetArchive, timeSeconds, globals) => {
       receiveNetGUIDBunch(bunch.archive, globals);
     }
 
-    if (bunch.bReliable && bunch.chSequence <= globals.inReliable) {
-      bunch.archive.popOffset(3);
+      if (bunch.bReliable && bunch.chSequence <= globals.inReliable) {
+        bunch.archive.popOffset(3, bunchDataBits);
 
       continue;
     }
 
-    if (!channel && !bunch.bReliable) {
-      if (!(bunch.bOpen && (bunch.bClose || bunch.bPartial))) {
-        bunch.archive.popOffset(3);
+      if (!channel && !bunch.bReliable) {
+        if (!(bunch.bOpen && (bunch.bClose || bunch.bPartial))) {
+          bunch.archive.popOffset(3, bunchDataBits);
 
-        continue;
+          continue;
+        }
       }
-    }
 
     if (!channel) {
       const newChannel = {};
@@ -153,11 +153,11 @@ const receivedPacket = (packetArchive, timeSeconds, globals) => {
       }
     } catch (ex) {
       console.log(ex);
-    } finally {
-      if (!bunch.bPartial && !ignoreChannel) {
-        bunch.archive.popOffset(3);
+      } finally {
+        if (!bunch.bPartial && !ignoreChannel) {
+          bunch.archive.popOffset(3, bunchDataBits);
+        }
       }
-    }
   }
 };
 

--- a/src/replayData/receivedReplicatorBunch.js
+++ b/src/replayData/receivedReplicatorBunch.js
@@ -90,7 +90,7 @@ const receivedReplicatorBunch = (bunch, archive, repObject, bHasRepLayout, bIsAc
       }
     } else if (fieldCache.isCustomStruct) {
       if (!receiveCustomProperty(archive, fieldCache, bunch, classNetCache.pathName, globalData, staticActorId)) {
-        archive.popOffset(5);
+        archive.popOffset(5, numPayloadBits);
 
         continue;
       }
@@ -102,19 +102,19 @@ const receivedReplicatorBunch = (bunch, archive, repObject, bHasRepLayout, bIsAc
       }
 
       if (!exportGroup || !netFieldParser.willReadType(exportGroup.pathName)) {
-        archive.popOffset(5);
+        archive.popOffset(5, numPayloadBits);
 
         continue;
       }
 
       if (receiveCustomDeltaProperty(archive, exportGroup, bunch, fieldCache.EnablePropertyChecksum || false, globalData, staticActorId)) {
-        archive.popOffset(5);
+        archive.popOffset(5, numPayloadBits);
 
         continue;
       }
     }
 
-    archive.popOffset(5);
+    archive.popOffset(5, numPayloadBits);
   }
 };
 


### PR DESCRIPTION
## Summary
- Pass expected bit counts to `popOffset` throughout replay parsing to improve error clarity
- Ensure packet and bunch handlers supply their sizes so boundary errors report correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaafbf5ba0832caf92e40dddc8cc4f