### PR TITLE
Improve elimination event parsing

### DIFF
--- a/debu.js
+++ b/debu.js
@@ -3,7 +3,7 @@ const path = require('path');
 const handleEventEmitter = require('./export/handleEventEmitter');
 const {
   loadReplayEliminations,
-  ELIMINATION_EVENT
+  ELIMINATION_EVENTS
 } = require('./elims');
 
 const usage = 'usage: node debug-elims.js <path/to/file.replay> [--max-samples=N] [--include-payloads] [--debug-netfields]';
@@ -171,7 +171,7 @@ async function main() {
     process.exit(1);
   }
 
-  const elimCount = result?.events?.elims?.length ?? 0;
+  const elimCount = result?.eliminations?.elims?.length ?? 0;
   const observedEventNames = Array.from(eventCounts.keys()).sort();
 
   console.log(`\nParsed replay: ${absoluteReplayPath}`);
@@ -207,7 +207,10 @@ async function main() {
     });
   }
 
-  console.log(`\nElimination handler listens to: ${ELIMINATION_EVENT}`);
+  console.log('\nElimination handler listens to:');
+  ELIMINATION_EVENTS.forEach((eventName) => {
+    console.log(`  • ${eventName}`);
+  });
 
   if (options.debugNetfields) {
     console.log('\nNet field export debug files were written next to the replay-reader executable.');

--- a/elims.js
+++ b/elims.js
@@ -1,38 +1,149 @@
 const parse = require('./index.js');
 const elimsClass = require('./exports/elims_classnetcache.json');
 const elimsPayload = require('./exports/elims_payload.json');
+const elimsPlayerStateClass = require('./exports/elims_playerstate_classnetcache.json');
+const elimsPlayerStatePayload = require('./exports/elims_playerstate_payload.json');
 
-const ELIMINATION_EVENT = 'FortniteGame.AthenaPlayerState:OnPlayerEliminationFeedUpdated';
+const ELIMINATION_EVENTS = [
+  'FortniteGame.AthenaPlayerState:OnPlayerEliminationFeedUpdated',
+  'FortniteGame.FortPlayerStateAthena:OnPlayerElimination'
+];
 const DEFAULT_NOT_READING_GROUPS = ['PlayerPawn_Athena.PlayerPawn_Athena_C'];
-const DEFAULT_EXPORTS = [elimsClass, elimsPayload];
+const DEFAULT_EXPORTS = [
+  elimsClass,
+  elimsPayload,
+  elimsPlayerStateClass,
+  elimsPlayerStatePayload
+];
 const noop = () => {};
+
+const CM_TO_METERS = 0.01;
+
+const sanitizeNumber = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (value && typeof value === 'object') {
+    const possible = Object.values(value).find((candidate) => typeof candidate === 'number');
+    if (typeof possible === 'number' && Number.isFinite(possible)) {
+      return possible;
+    }
+  }
+
+  return undefined;
+};
+
+const deriveDistanceFromLocations = (eliminatorLocation, eliminatedLocation) => {
+  if (!eliminatorLocation || !eliminatedLocation) {
+    return undefined;
+  }
+
+  const keys = ['x', 'y', 'z'];
+  const values = keys.map((key) => {
+    const eliminatorCoord = sanitizeNumber(eliminatorLocation[key]);
+    const eliminatedCoord = sanitizeNumber(eliminatedLocation[key]);
+
+    if (eliminatorCoord === undefined || eliminatedCoord === undefined) {
+      return undefined;
+    }
+
+    return eliminatorCoord - eliminatedCoord;
+  });
+
+  if (values.some((value) => value === undefined)) {
+    return undefined;
+  }
+
+  const squared = values.reduce((total, delta) => total + delta * delta, 0);
+  const meters = Math.sqrt(squared) * CM_TO_METERS;
+
+  return Number.isFinite(meters) ? meters : undefined;
+};
+
+const extractDistance = (data) => {
+  const directDistance = [
+    data.Distance,
+    data.DistanceMeters,
+    data.EliminationDistance
+  ].map(sanitizeNumber).find((value) => value !== undefined);
+
+  if (directDistance !== undefined) {
+    return directDistance;
+  }
+
+  const squaredMeters = sanitizeNumber(data.DistanceMetersSquared);
+  if (squaredMeters !== undefined) {
+    const meters = Math.sqrt(squaredMeters);
+    if (Number.isFinite(meters)) {
+      return meters;
+    }
+  }
+
+  const vectorDistance = deriveDistanceFromLocations(
+    data.EliminatorLocation ?? data.FinisherLocation,
+    data.EliminatedLocation ?? data.VictimLocation
+  );
+
+  if (vectorDistance !== undefined) {
+    return vectorDistance;
+  }
+
+  return undefined;
+};
 
 const normalizeElimination = (data, timeSeconds) => ({
   killer: data.EliminatorId,
   victim: data.EliminatedId,
   weapon: data.GunType,
   knocked: !!data.bKnocked,
-  distance: data.Distance,
+  distance: extractDistance(data),
   t: data.TimeSeconds ?? timeSeconds
 });
 
+const createEliminationKey = (elim) => {
+  try {
+    return JSON.stringify({
+      killer: elim.killer,
+      victim: elim.victim,
+      weapon: elim.weapon,
+      knocked: elim.knocked,
+      t: elim.t
+    });
+  } catch (err) {
+    return undefined;
+  }
+};
+
 const makeEliminationHandler = ({ onElimination } = {}) =>
   ({ propertyExportEmitter, parsingEmitter }) => {
+    const seen = new Set();
     parsingEmitter.on('log', noop);
-    propertyExportEmitter.on(
-      ELIMINATION_EVENT,
-      ({ data, result, timeSeconds }) => {
-        const normalized = normalizeElimination(data, timeSeconds);
+    ELIMINATION_EVENTS.forEach((eventName) => {
+      propertyExportEmitter.on(
+        eventName,
+        ({ data, result, timeSeconds }) => {
+          const normalized = normalizeElimination(data, timeSeconds);
+          const key = createEliminationKey(normalized);
 
-        result.events ??= {};
-        result.events.elims ??= [];
-        result.events.elims.push(normalized);
+          if (key && seen.has(key)) {
+            return;
+          }
 
-        if (typeof onElimination === 'function') {
-          onElimination(normalized, { data, result, timeSeconds });
+          if (key) {
+            seen.add(key);
+          }
+
+          result.eliminations ??= {};
+          result.eliminations.elims ??= [];
+          result.eliminations.elims.push(normalized);
+
+          if (typeof onElimination === 'function') {
+            onElimination(normalized, { data, result, timeSeconds });
+          }
         }
-      }
-    );
+      );
+    });
   };
 
 const composeHandlers = (primary, secondary) => {
@@ -72,16 +183,18 @@ const loadReplayEliminations = async (buffer, { onElimination, parseOptions = {}
 
   return {
     result,
-    elims: result?.events?.elims ?? []
+    elims: result?.eliminations?.elims ?? []
   };
 };
 
 module.exports = {
-  ELIMINATION_EVENT,
+  ELIMINATION_EVENTS,
   DEFAULT_EXPORTS,
   DEFAULT_NOT_READING_GROUPS,
   elimsClass,
   elimsPayload,
+  elimsPlayerStateClass,
+  elimsPlayerStatePayload,
   loadReplayEliminations,
   makeEliminationHandler
 };

--- a/exports/elims_playerstate_classnetcache.json
+++ b/exports/elims_playerstate_classnetcache.json
@@ -1,0 +1,14 @@
+{
+  "path": ["FortPlayerStateAthena_C_ClassNetCache"],
+  "customExportName": "FortniteGame.FortPlayerStateAthena:OnPlayerElimination",
+  "parseLevel": 1,
+  "type": "ClassNetCache",
+  "properties": {
+    "OnPlayerElimination": {
+      "name": "OnPlayerElimination",
+      "type": "/Script/FortniteGame.FortPlayerStateAthena:OnPlayerElimination",
+      "isFunction": true,
+      "isCustomStruct": false
+    }
+  }
+}

--- a/exports/elims_playerstate_payload.json
+++ b/exports/elims_playerstate_payload.json
@@ -1,5 +1,5 @@
 {
-  "path": ["/Script/FortniteGame.AthenaPlayerState:OnPlayerEliminationFeedUpdated"],
+  "path": ["/Script/FortniteGame.FortPlayerStateAthena:OnPlayerElimination"],
   "parseLevel": 1,
   "exportGroup": "eliminations",
   "exportName": "elims",
@@ -7,9 +7,11 @@
   "properties": {
     "EliminatorId": { "name": "EliminatorId", "parseFunction": "readNetId", "parseType": "default" },
     "EliminatedId": { "name": "EliminatedId", "parseFunction": "readNetId", "parseType": "default" },
-    "GunType":      { "name": "GunType",      "parseFunction": "readInt32", "parseType": "default" },
-    "bKnocked":     { "name": "bKnocked",     "parseFunction": "readBit",   "parseType": "default" },
-    "Distance":     { "name": "Distance",     "parseFunction": "readInt32", "parseType": "default" },
+    "FinisherId": { "name": "FinisherId", "parseFunction": "readNetId", "parseType": "default" },
+    "AssistId": { "name": "AssistId", "parseFunction": "readNetId", "parseType": "default" },
+    "GunType": { "name": "GunType", "parseFunction": "readInt32", "parseType": "default" },
+    "bKnocked": { "name": "bKnocked", "parseFunction": "readBit", "parseType": "default" },
+    "Distance": { "name": "Distance", "parseFunction": "readInt32", "parseType": "default" },
     "EliminationDistance": { "name": "EliminationDistance", "parseFunction": "readFloat32", "parseType": "default" },
     "DistanceMeters": { "name": "DistanceMeters", "parseFunction": "readFloat32", "parseType": "default" },
     "DistanceMetersSquared": { "name": "DistanceMetersSquared", "parseFunction": "readFloat32", "parseType": "default" },
@@ -17,6 +19,6 @@
     "FinisherLocation": { "name": "FinisherLocation", "parseFunction": "readPackedVector100", "parseType": "default" },
     "EliminatedLocation": { "name": "EliminatedLocation", "parseFunction": "readPackedVector100", "parseType": "default" },
     "VictimLocation": { "name": "VictimLocation", "parseFunction": "readPackedVector100", "parseType": "default" },
-    "TimeSeconds":  { "name": "TimeSeconds",  "parseFunction": "readInt32", "parseType": "default" }
+    "TimeSeconds": { "name": "TimeSeconds", "parseFunction": "readInt32", "parseType": "default" }
   }
 }

--- a/inspect-elims.js
+++ b/inspect-elims.js
@@ -20,8 +20,29 @@ const formatNetId = (value) => {
   return String(value);
 };
 
+const formatDistance = (value) => {
+  if (value === null || value === undefined) {
+    return 'n/a';
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return String(value);
+  }
+
+  if (Math.abs(numeric) >= 100) {
+    return numeric.toFixed(1);
+  }
+
+  if (Math.abs(numeric) >= 10) {
+    return numeric.toFixed(2);
+  }
+
+  return numeric.toFixed(3);
+};
+
 const formatElimination = (elim, index, total) => {
-  const distance = elim.distance ?? 'n/a';
+  const distance = formatDistance(elim.distance);
   const label = typeof index === 'number' && typeof total === 'number'
     ? `${index}/${total}`
     : undefined;


### PR DESCRIPTION
## Summary
- register elimination handlers for both elimination feed and FortPlayerState events while deduplicating results and storing them under a dedicated eliminations bucket
- extend elimination payload parsing so distance and position fields are captured for reliable distance extraction
- expose the tracked elimination events in the debugging helper and add the necessary NetField export definitions for the new event payloads

## Testing
- not run (npm unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68efe2566dd0832cb1ba98a7cbfa45a4