### PR TITLE
Add CLI script to dump full parsed replay JSON

### DIFF
--- a/dump-full-parse.js
+++ b/dump-full-parse.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const parse = require('./index');
+
+const usage = 'Usage: node dump-full-parse.js <input.replay> [output.json]';
+
+const [, , inputPath, outputPath] = process.argv;
+
+if (!inputPath) {
+  console.error(usage);
+  process.exit(1);
+}
+
+const resolvedInputPath = path.resolve(process.cwd(), inputPath);
+const resolvedOutputPath = outputPath ? path.resolve(process.cwd(), outputPath) : null;
+
+let replayBuffer;
+try {
+  replayBuffer = fs.readFileSync(resolvedInputPath);
+} catch (error) {
+  console.error(`Failed to read replay file at "${resolvedInputPath}": ${error.message}`);
+  process.exit(1);
+}
+
+const replacer = (key, value) => {
+  if (value instanceof Buffer) {
+    return {
+      type: 'Buffer',
+      data: value.toString('base64'),
+    };
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  return value;
+};
+
+(async () => {
+  try {
+    const parsed = await parse(replayBuffer, {
+      parseEvents: true,
+      parsePackets: true,
+      parseLevel: 10,
+    });
+
+    const json = JSON.stringify(parsed, replacer, 2);
+
+    if (resolvedOutputPath) {
+      fs.writeFileSync(resolvedOutputPath, json);
+      console.log(`Wrote parsed replay JSON to ${resolvedOutputPath}`);
+    } else {
+      console.log(json);
+    }
+  } catch (error) {
+    console.error(`Failed to parse replay file: ${error.message}`);
+    if (error && error.stack) {
+      console.error(error.stack);
+    }
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a dump-full-parse.js CLI helper that uses the existing parser to output all parsed replay data
- serialize buffers and bigint values so the dump can be stored as JSON
- support writing to stdout or an optional destination file

## Testing
- node dump-full-parse.js test.replay (fails: missing module ooz-wasm in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f0969df5a4832cab1d8c471bb4b96e