### PR TITLE
Expose elimination distances in full replay dump

### DIFF
--- a/dump-full-parse.js
+++ b/dump-full-parse.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const parse = require('./index');
+const { loadReplayEliminations } = require('./elims');
 
 const usage = 'Usage: node dump-full-parse.js <input.replay> [output.json]';
 
@@ -41,10 +41,12 @@ const replacer = (key, value) => {
 
 (async () => {
   try {
-    const parsed = await parse(replayBuffer, {
-      parseEvents: true,
-      parsePackets: true,
-      parseLevel: 10,
+    const { result: parsed } = await loadReplayEliminations(replayBuffer, {
+      parseOptions: {
+        parseEvents: true,
+        parsePackets: true,
+        parseLevel: 10,
+      },
     });
 
     const json = JSON.stringify(parsed, replacer, 2);


### PR DESCRIPTION
## Summary
- update the full parse dumper to reuse the elimination-aware replay loader
- merge property-derived elimination metadata with raw player elimination events, exposing distances when available
- store the combined elimination list on the parsed result for downstream tooling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f09d3aba10832cb8ffb669c60f4bc4